### PR TITLE
Partially fix 'mkdir --recursive' on Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .packages/
 /build/
+/.test-*

--- a/src/directory.toit
+++ b/src/directory.toit
@@ -51,6 +51,11 @@ mkdir --recursive/bool path/string mode/int=0x1ff -> none:
     mkdir path mode
     return
 
+  // TODO(florian): This doesn't work for UNC drives on Windows.
+  // We must not split the volume name.
+  if system.platform == system.PLATFORM-WINDOWS:
+    path = path.replace "\\" "/"
+
   built_path := ""
   parts := path.split "/"
   parts.size.repeat:

--- a/src/directory.toit
+++ b/src/directory.toit
@@ -54,7 +54,7 @@ mkdir --recursive/bool path/string mode/int=0x1ff -> none:
   // TODO(florian): This doesn't work for UNC drives on Windows.
   // We must not split the volume name.
   if system.platform == system.PLATFORM-WINDOWS:
-    path = path.replace "\\" "/"
+    path = path.replace --all "\\" "/"
 
   built_path := ""
   parts := path.split "/"

--- a/tests/mkdir_rmdir_test.toit
+++ b/tests/mkdir_rmdir_test.toit
@@ -17,7 +17,7 @@ with_tmp_dir [block]:
 
 main:
   with_tmp_dir: | tmp_dir |
-    ["foo", "føo", "f€o", "f😀o"].do: | name |
+    ["test-foo", "test-føo", "test-f€o", "test-f😀o"].do: | name |
       // Create relative directory in the current working directory.
       // Pollutes the current working directory, but we want to test
       // relative directory creation.
@@ -26,6 +26,7 @@ main:
       expect (file.is_directory name)
       print "Remove name"
       rmdir name
+      expect_not (file.is_directory name)
 
       tmp_name := "$tmp_dir/$name"
       print "Make $tmp_name"
@@ -33,20 +34,25 @@ main:
       expect (file.is_directory tmp_name)
       print "Remove $tmp_dir/name"
       rmdir tmp_name
+      expect_not (file.is_directory name)
 
-    mkdir --recursive "foo/bar/gee"
-    expect (file.is_directory "foo/bar/gee")
-    rmdir --recursive "foo/bar/gee"
+    mkdir --recursive "test-foo/bar/gee"
+    expect (file.is_directory "test-foo/bar/gee")
+    rmdir --recursive "test-foo"
+    expect_not (file.is_directory "test-foo")
 
-    mkdir --recursive "$tmp_dir/foo/bar/gee"
-    expect (file.is_directory "$tmp_dir/foo/bar/gee")
-    rmdir --recursive "$tmp_dir/foo/bar/gee"
+    mkdir --recursive "$tmp_dir/test-foo/bar/gee"
+    expect (file.is_directory "$tmp_dir/test-foo/bar/gee")
+    rmdir --recursive "$tmp_dir/test-foo"
+    expect_not (file.is_directory "$tmp_dir/test-foo")
 
     if system.platform == system.PLATFORM-WINDOWS:
-      mkdir --recursive "foo\\bar\\gee"
-      expect (file.is_directory "foo\\bar\\gee")
-      rmdir --recursive "foo\\bar\\gee"
+      mkdir --recursive "test-foo\\bar\\gee"
+      expect (file.is_directory "test-foo\\bar\\gee")
+      rmdir --recursive "test-foo"
+      expect_not (file.is_directory "test-foo")
 
-      mkdir --recursive "$tmp_dir\\foo\\bar\\gee"
-      expect (file.is_directory "$tmp_dir\\foo\\bar\\gee")
-      rmdir --recursive "$tmp_dir\\foo\\bar\\gee"
+      mkdir --recursive "$tmp_dir\\test-foo\\bar\\gee"
+      expect (file.is_directory "$tmp_dir\\test-foo\\bar\\gee")
+      rmdir --recursive "$tmp_dir\\test-foo"
+      expect_not (file.is_directory "$tmp_dir\\test-foo")

--- a/tests/mkdir_rmdir_test.toit
+++ b/tests/mkdir_rmdir_test.toit
@@ -3,30 +3,50 @@
 // be found in the tests/TESTS_LICENSE file.
 
 import expect show *
+import system
 
 import host.file
 import host.directory show *
-import writer show Writer
 
-expect_ name [code]:
-  expect
-    (catch code).starts_with name
-
-expect_out_of_bounds [code]:
-  expect_ "OUT_OF_BOUNDS" code
-
-expect_file_not_found [code]:
-  expect_ "FILE_NOT_FOUND" code
-
-expect_invalid_argument [code]:
-  expect_ "INVALID_ARGUMENT" code
-
-expect_already_closed [code]:
-  expect_ "ALREADY_CLOSED" code
+with_tmp_dir [block]:
+  tmp_dir := mkdtemp
+  try:
+    block.call tmp_dir
+  finally:
+    rmdir --recursive tmp_dir
 
 main:
-  ["foo", "føo", "f€o", "f😀o"].do: | name |
-    print "Make $name"
-    mkdir name
-    print "Remove $name"
-    rmdir name
+  with_tmp_dir: | tmp_dir |
+    ["foo", "føo", "f€o", "f😀o"].do: | name |
+      // Create relative directory in the current working directory.
+      // Pollutes the current working directory, but we want to test
+      // relative directory creation.
+      print "Make $name"
+      mkdir name
+      expect (file.is_directory name)
+      print "Remove name"
+      rmdir name
+
+      tmp_name := "$tmp_dir/$name"
+      print "Make $tmp_name"
+      mkdir tmp_name
+      expect (file.is_directory tmp_name)
+      print "Remove $tmp_dir/name"
+      rmdir tmp_name
+
+    mkdir --recursive "foo/bar/gee"
+    expect (file.is_directory "foo/bar/gee")
+    rmdir --recursive "foo/bar/gee"
+
+    mkdir --recursive "$tmp_dir/foo/bar/gee"
+    expect (file.is_directory "$tmp_dir/foo/bar/gee")
+    rmdir --recursive "$tmp_dir/foo/bar/gee"
+
+    if system.platform == system.PLATFORM-WINDOWS:
+      mkdir --recursive "foo\\bar\\gee"
+      expect (file.is_directory "foo\\bar\\gee")
+      rmdir --recursive "foo\\bar\\gee"
+
+      mkdir --recursive "$tmp_dir\\foo\\bar\\gee"
+      expect (file.is_directory "$tmp_dir\\foo\\bar\\gee")
+      rmdir --recursive "$tmp_dir\\foo\\bar\\gee"


### PR DESCRIPTION
The function was assuming that the path was using '/' separators.