### PR TITLE
Make copying more predictable.

### DIFF
--- a/src/file.toit
+++ b/src/file.toit
@@ -469,7 +469,7 @@ copy_ -> none
     if not target-stat:
       mkdir target source-permissions
       if is-windows and source-permissions & SPECIAL-WINDOWS-PERMISSIONS_ != 0:
-        // The Windows file attributes are not taking into account when creating a new directory.
+        // The Windows file attributes are not taken into account when creating a new directory.
         // Apply them now.
         chmod target source-permissions
 
@@ -486,7 +486,7 @@ copy_ -> none
     in-stream.close
     out-writer.close
   if is-windows and (source-permissions & SPECIAL-WINDOWS-PERMISSIONS_) != 0:
-    // The Windows file attributes are not taking into account when creating a new file.
+    // The Windows file attributes are not taken into account when creating a new file.
     // Apply them now.
     chmod target source-permissions
 

--- a/tests/copy_test.toit
+++ b/tests/copy_test.toit
@@ -16,8 +16,8 @@ with-tmp-dir [block]:
     directory.rmdir --force --recursive tmp-dir
 
 main:
-  // test-recursive
-  // test-permissions
+  test-recursive
+  test-permissions
   test-symlinks
 
 test-recursive:
@@ -34,16 +34,9 @@ test-recursive:
     file.copy --source=tmp-file --target=file2
     expect-equals content (file.read-content file2)
 
-    // Copy of absolute path to absolute directory path.
-    subdir := "$tmp-dir/subdir"
-    directory.mkdir subdir
-    sub-file := "$subdir/file.txt"
-    file.copy --source=tmp-file --target=subdir
-    expect-equals content (file.read-content sub-file)
-
     // Copy of relative file to relative directory path.
     directory.mkdir "subdir2"
-    file.copy --source="file.txt" --target="subdir2"
+    file.copy --source="file.txt" --target="subdir2/file.txt"
     expect-equals content (file.read-content "subdir2/file.txt")
     expect-equals content (file.read-content "$tmp-dir/subdir2/file.txt")
 
@@ -53,6 +46,12 @@ test-recursive:
     file.copy --source="subdir2" --target="subdir3" --recursive
     expect-equals content (file.read-content "subdir3/file.txt")
     expect-equals other-content (file.read-content "subdir3/nested-subdir/other.txt")
+
+    // Copy recursive to existing directory.
+    directory.mkdir "subdir4"
+    file.copy --source="subdir3" --target="subdir4" --recursive
+    expect-equals content (file.read-content "subdir4/file.txt")
+    expect-equals other-content (file.read-content "subdir4/nested-subdir/other.txt")
 
 test-permissions:
   file-permission0/int := ?

--- a/tests/copy_test.toit
+++ b/tests/copy_test.toit
@@ -59,10 +59,12 @@ test-permissions:
   dir-permission/int := ?
   read-only-dir-permission/int := ?
   if platform == PLATFORM-WINDOWS:
-    file-permission0 = file.WINDOWS-FILE-ATTRIBUTE-HIDDEN | file.WINDOWS-FILE-ATTRIBUTE-NORMAL
-    file-permission1 = file.WINDOWS-FILE-ATTRIBUTE-READONLY | file.WINDOWS-FILE-ATTRIBUTE-NORMAL
-    dir-permission = 0
-    read-only-dir-permission = file.WINDOWS-FILE-ATTRIBUTE-READONLY
+    // We use the "archive" attribute, since we modify the files, and this is the default
+    // attribute for modified files. The idea is that the backup software clears this bit.
+    file-permission0 = file.WINDOWS-FILE-ATTRIBUTE-HIDDEN | file.WINDOWS-FILE-ATTRIBUTE-ARCHIVE
+    file-permission1 = file.WINDOWS-FILE-ATTRIBUTE-READONLY | file.WINDOWS-FILE-ATTRIBUTE-ARCHIVE
+    dir-permission = file.WINDOWS-FILE-ATTRIBUTE-DIRECTORY
+    read-only-dir-permission = file.WINDOWS-FILE-ATTRIBUTE-READONLY | file.WINDOWS-FILE-ATTRIBUTE-DIRECTORY
   else:
     file-permission0 = 0b111_000_000
     file-permission1 = 0b100_000_000


### PR DESCRIPTION
Don't make the copy operation dependent on whether the target directory exists or not.
Making it dependent has the following drawbacks:
1. the directory could be created outside of our control.
2. It's annoying in programs to test first whether the target exists.
3. There isn't a good way to copy the content of the source to the target if it already exists.