### PR TITLE
Fix path joining in 'find-executable'.

### DIFF
--- a/src/file.toit
+++ b/src/file.toit
@@ -575,6 +575,9 @@ Returns null if no such executable is found.
 Returns a path relative to the part of the PATH where the executable is found.
   For example, if the PATH contains `..` and the executable is found there,
   then `../name` (or `..\name`) is returned.
+Follows shell semantics and treats an empty entry of the PATH as the current
+  directory, so an executable found through one is returned as `./name`
+  (or `.\name`).
 */
 find-executable name/string -> string?:
   bin-paths := ?
@@ -594,14 +597,16 @@ find-executable name/string -> string?:
     bin-paths = path-env.split ":"
     extensions = [""]
 
+  is-windows := system.platform == system.PLATFORM-WINDOWS
+  separator := is-windows ? "\\" : "/"
   bin-paths.do: | bin-path/string |
-    is-windows := system.platform == system.PLATFORM-WINDOWS
-    separator := is-windows ? "\\" : "/"
+    // An empty entry stands for the current directory.
+    dir := bin-path == "" ? "." : bin-path
     extensions.do: | ext/string |
-      candidate := if bin-path.ends-with "/" or bin-path.ends-with "\\":
-        "$bin-path$name$ext"
+      candidate := if dir.ends-with "/" or dir.ends-with "\\":
+        "$dir$name$ext"
       else:
-        "$bin-path/$separator$name$ext"
+        "$dir$separator$name$ext"
       if is-file candidate:
         if is-windows:
           // On Windows, just being a file is enough.

--- a/tests/find-executable_test.toit
+++ b/tests/find-executable_test.toit
@@ -5,10 +5,16 @@
 import expect show *
 
 import host.file
+import host.os
 import host.pipe
 import system
 
 main:
+  test-shell
+  test-empty-path-entry
+  expect-null (file.find-executable "this_executable_does_not_exist")
+
+test-shell:
   shell/string := ?
   shell-args := ?
   if system.platform == system.PLATFORM-WINDOWS:
@@ -23,8 +29,39 @@ main:
   path := file.find-executable shell
   expect-not-null path
 
+  // The path must join the PATH entry and the name with a single separator.
+  if system.platform == system.PLATFORM-WINDOWS:
+    expect-not (path.contains "\\\\")
+    expect-not (path.contains "/\\")
+  else:
+    expect-not (path.contains "//")
+
   // Run the found executable to verify it works.
   output := pipe.backticks [path] + shell-args
   expect-equals "hello" output.trim
 
-  expect-null (file.find-executable "this_executable_does_not_exist")
+/**
+Tests that an empty entry of the PATH is treated as the current directory.
+*/
+test-empty-path-entry:
+  is-windows := system.platform == system.PLATFORM-WINDOWS
+  separator := is-windows ? "\\" : "/"
+  name := "find-executable-tool"
+  // On Windows the extension must be one of the PATHEXT entries, which we
+  // pin below.
+  filename := is-windows ? "$(name).bat" : name
+
+  old-path := os.env.get "PATH"
+  old-pathext := os.env.get "PATHEXT"
+  file.write-contents "" --path=filename --permissions=0b111_101_101
+
+  // A trailing separator leaves an empty entry at the end of the PATH.
+  // The tool only exists in the current directory, so it can only be found
+  // through that empty entry.
+  os.env["PATH"] = is-windows ? "C:\\does-not-exist;" : "/does-not-exist:"
+  if is-windows: os.env["PATHEXT"] = ".bat"
+  expect-equals ".$separator$filename" (file.find-executable name)
+
+  file.delete filename
+  if old-path: os.env["PATH"] = old-path
+  if old-pathext: os.env["PATHEXT"] = old-pathext


### PR DESCRIPTION
## The double separator

`find-executable` built its candidate paths with both a literal `/` *and* the `$separator` variable:

```
"$bin-path/$separator$name$ext"
```

So every returned path got two separators — `file.find-executable "sh"` returned `/usr/bin//sh`. The same typo mixed the two separator styles on Windows, producing `C:\bin/\name`.

## The empty PATH entry

An empty entry in the PATH conventionally means "the current directory" (a trailing `:`, as in `PATH=/usr/bin:`). The old code turned it into `/name` — an absolute path at the root of the file system — so an executable in the current directory was never found. It is now treated as `.`, and returned as `./name`, which fits the documented behaviour of returning a path relative to the part of the PATH where the executable was found.

Note that Windows' own `SearchPath` ignores empty entries rather than mapping them to the current directory. Since Windows searches the current directory anyway the net result is the same, and Go's `exec.LookPath` ends up in the same place, so this handles both platforms uniformly. Happy to skip empty entries on Windows instead if you'd prefer.

## Tests

The existing test only asserted that the result was non-null and that it could be run. A doubled separator satisfies both — the OS resolves `/usr/bin//sh` just fine — which is why this went unnoticed. The test now checks the joined path itself.

The new empty-entry test sets `PATH` in-process via `os.env[]=` to a nonexistent directory plus a trailing empty entry, so the tool it writes into the current directory can only be found through that empty entry.
